### PR TITLE
Add SPDX License Identifier

### DIFF
--- a/awecron
+++ b/awecron
@@ -1,6 +1,9 @@
 #!/bin/bash
 # Note: the code is very commented for convenience and newbies (not to annoy)
 
+# SPDX-License-Identifier: MIT
+
+
 main () {
          # runs through all dirs that contain "timer" file
         for t in "$repo"/*/timer; do


### PR DESCRIPTION
This pull request adds the project license header in the official [SPDX License Identifier](https://spdx.dev/learn/handling-license-info/) format, making it [ISO 5962:2021](https://iso.org/standard/81870.html)-compilant. This should be applied to all text-based source files within the project if there are more than only this one.

A copyright string should also be added, but this is not a part of the standard.